### PR TITLE
Fix installer from prompting about chmod

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -15,4 +15,4 @@ release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME"
 
 # Download tar.gz file to the download directory
 download_release "$ASDF_INSTALL_VERSION" "$release_file"
-chmod 0554 "$release_file"
+chmod 0755 "$release_file"


### PR DESCRIPTION
- chore: release 0.1.0
- fix: Stop the installer from prompting about chmod
